### PR TITLE
AVX-25383 [mc-gw] Add missing advanced VPC options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ The following variables are optional:
 | :------------: | :------------: | :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------: |
 |  insane_mode   |  AWS<br>Azure  |     false     |                                       Set to true to enable Aviatrix high performance encryption                                        |
 | single_ip_snat |      ALL       |     false     | Set to true to enable Source NAT feature in single_ip mode on the gateway. Please disable AWS NAT instance before enabling this feature |
-
+|       num_of_subnet_pairs       |      AWS, Azure       |          | Number of public subnet and private subnet pair created. Only Support AWS, Azure Provider |
+|       subnet_size               |      AWS, Azure       |          | Subnet Size. Only Supported for AWS, Azure Provider |
+|       resource_group            |      Azure       |          | Resource Group of the Azure VPC created |
 ### VPN options
 |       Attribute        |   Supported CSPs    |  Default value  |                                                                     Description                                                                      |
 | :--------------------: | :-----------------: | :-------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: |

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,9 @@ resource "aviatrix_vpc" "default" {
   cidr         = local.cloud == "gcp" ? null : var.cidr
   name         = local.name
 
-  # subnet_size = 
-  # num_subnet_pairs = 
-  # resource_group = 
-
+  subnet_size         = local.subnet_size
+  resource_group      = var.resource_group
+  num_of_subnet_pairs = local.num_of_subnet_pairs
   dynamic "subnets" {
     for_each = local.cloud == "gcp" ? ["dummy"] : [] # Workaround to make block conditional. Count not available on dynamic blocks
     content {
@@ -55,8 +54,7 @@ resource "aviatrix_gateway" "default" {
   customer_managed_keys = local.customer_managed_keys
   tags                  = var.tags
 
-  single_ip_snat = var.single_ip_snat
-
+  single_ip_snat            = var.single_ip_snat
   insane_mode               = var.insane_mode
   insane_mode_az            = local.insane_mode_az
   peering_ha_insane_mode_az = var.enable_ha ? local.ha_insane_mode_az : null

--- a/variables.tf
+++ b/variables.tf
@@ -186,6 +186,24 @@ variable "single_ip_snat" {
   default     = false
 }
 
+variable "subnet_size" {
+  description = "Size of each cidr block in bits"
+  type        = number
+  default     = null
+}
+
+variable "num_of_subnet_pairs" {
+  description = "Number of public subnet and private subnet pair created in the VPC"
+  type        = number
+  default     = null
+}
+
+variable "resource_group" {
+  description = "The name of an existing resource group or a new resource group to be created for the Azure VNet"
+  type        = string
+  default     = ""
+}
+
 ## VPN options
 variable "enable_vpn" {
   description = "Set to true to enable user access through VPN to this gateway"
@@ -325,6 +343,18 @@ locals {
     gcp   = "n1-standard-1",
     azure = "Standard_B1ms",
     oci   = "VM.Standard2.2"
+  }
+
+  num_of_subnet_pairs = var.num_of_subnet_pairs != null ? var.num_of_subnet_pairs : lookup(local.num_of_subnet_pairs_map, local.cloud, null)
+  num_of_subnet_pairs_map = {
+    azure = 2,
+    aws   = 2,
+  }
+
+  subnet_size = var.subnet_size != null ? var.subnet_size : lookup(local.subnet_size_map, local.cloud, null)
+  subnet_size_map = {
+    azure = 28,
+    aws   = 28,
   }
 
   az1 = length(var.az1) > 0 ? var.az1 : lookup(local.az1_map, local.cloud, null)


### PR DESCRIPTION
# New

Add the following input options to this module for the VPC:
- subnet_size
- num_of_subnet_pairs
- resource_group
[Reference]: https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs/resources/aviatrix_vpc#advanced-options 
[Source Code]:  https://github.com/terraform-aviatrix-modules/terraform-aviatrix-mc-gateway