### PR TITLE
Add custom EIP setting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Deploys a VPC/VNet/VCN and Aviatrix gateway. It is also possible to use an exist
 
 | Module version | Terraform version | Controller version | Terraform provider version |
 | :------------: | :---------------: | :----------------: | :------------------------: |
+|     v1.3.1     |       >=1.0       |       >=7.0        |          ~>3.0.0           |
 |     v1.3.0     |       >=1.0       |       >=7.0        |          ~>3.0.0           |
 |     v1.2.0     |       >=1.0       |       >=6.9        |          ~>2.24.0          |
 |     v1.1.0     |       >=1.0       |       >=6.8        |          ~>2.23.0          |
@@ -53,18 +54,23 @@ The following variables are optional:
 
 ### GW options
 
-|       Attribute       |   Supported CSPs    | Default value  |                                                Description                                                 |
-| :-------------------: | :-----------------: | :------------: | :--------------------------------------------------------------------------------------------------------: |
-|   use_existing_vpc    |         ALL         |     false      |                        Set to true to use an existing VPC instead of launching one                         |
-|        vpc_id         |         ALL         |                |          VPC ID of an existing VPC, to launch gateway in. Required if `use_existing_vpc` is true           |
-|       gw_subnet       |         ALL         |                |        Subnet CIDR of an existing VPC, to launch gateway in. Required if `use_existing_vpc` is true        |
-|      hagw_subnet      |         ALL         |                | Subnet CIDR of existing VPC, to launch HA gateway in. Required if `enable_ha` & `use_existing_vpc` is true |
-| enable_encrypt_volume |         AWS         |      true      |                    Set to true to enable encryption of the EBS volume of the gateway(s)                    |
-| customer_managed_keys |         AWS         |                |                     AWS customer-managed key ID, to be used to encrypt the EBS volume                      |
-|         tags          |    AWS<br>Azure     |                |                                    Map of tags to assign to the gateway                                    |
-|          az1          | AWS<br>Azure<br>GCP | a<br>az-1<br>b |           Concatenate with region to form az names. eg. eu-central-1a. Used for Insane Mode only           |
-|          az2          | AWS<br>Azure<br>GCP | b<br>az-2<br>c |           Concatenate with region to form az names. eg. eu-central-1b. Used for Insane Mode only           |
-|      az_support       |        Azure        |      true      |                                 Set to true if Azure region supports AZ's                                  |
+|            Attribute             |   Supported CSPs    | Default value  |                                                                    Description                                                                    |
+| :------------------------------: | :-----------------: | :------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------: |
+|         use_existing_vpc         |         ALL         |     false      |                                            Set to true to use an existing VPC instead of launching one                                            |
+|              vpc_id              |         ALL         |                |                              VPC ID of an existing VPC, to launch gateway in. Required if `use_existing_vpc` is true                              |
+|            gw_subnet             |         ALL         |                |                           Subnet CIDR of an existing VPC, to launch gateway in. Required if `use_existing_vpc` is true                            |
+|           hagw_subnet            |         ALL         |                |                    Subnet CIDR of existing VPC, to launch HA gateway in. Required if `enable_ha` & `use_existing_vpc` is true                     |
+|      enable_encrypt_volume       |         AWS         |      true      |                                       Set to true to enable encryption of the EBS volume of the gateway(s)                                        |
+|      customer_managed_keys       |         AWS         |                |                                         AWS customer-managed key ID, to be used to encrypt the EBS volume                                         |
+|               tags               |    AWS<br>Azure     |                |                                                       Map of tags to assign to the gateway                                                        |
+|               az1                | AWS<br>Azure<br>GCP | a<br>az-1<br>b |                              Concatenate with region to form az names. eg. eu-central-1a. Used for Insane Mode only                               |
+|               az2                | AWS<br>Azure<br>GCP | b<br>az-2<br>c |                              Concatenate with region to form az names. eg. eu-central-1b. Used for Insane Mode only                               |
+|            az_support            |        Azure        |      true      |                                                     Set to true if Azure region supports AZ's                                                     |
+|         allocate_new_eip         |         ALL         |      true      |    Set to false to reuse an idle address in Elastic IP pool for this gateway. Otherwise, allocate a new Elastic IP and use it for this gateway    |
+|               eip                |         ALL         |                |                               Required when `allocate_new_eip` is false. It uses the specified EIP for this gateway                               |
+|              ha_eip              |         ALL         |                |                             Required when `allocate_new_eip` is false. It uses the specified EIP for this HA gateway                              |
+|  azure_eip_name_resource_group   |        Azure        |                |  Name of public IP Address resource and its resource group in Azure to be assigned to the gateway instance. eg: <IP_Name>:<Resource_Group_Name>   |
+| ha_azure_eip_name_resource_group |        Azure        |                | Name of public IP Address resource and its resource group in Azure to be assigned to the HA gateway instance. eg: <IP_Name>:<Resource_Group_Name> |
 
 ### Advanced options
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # terraform-aviatrix-mc-gateway - release notes
 
+## v1.3.1
+### Add support for setting custom IP addresses
+- Gateway now supports specifying the public IP address for both the primary and HA instance through the use of the following variables:
+  - ``allocate_new_eip``
+  - ``eip``
+  - ``ha_eip``
+  - ``azure_eip_name_resource_group``
+  - ``ha_azure_eip_name_resource_group``
+- This feature is available for all the current supported CSPs: AWS, Azure, GCP, and OCI
+
 ## v1.3.0
 ### Add support for Controller 7.0 and provider version 3.0.0.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ The following examples will launch a new VPC + gateway with HA and Insane Mode (
 # AWS
 module aws_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "aws"
     name    = "foo-aws"
@@ -32,7 +32,7 @@ module aws_gw_module {
 # Azure
 module arm_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "azure"
     name    = "foo-azure"
@@ -53,7 +53,7 @@ module arm_gw_module {
 # GCP
 module gcp_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "gcp"
     name    = "foo-gcp"
@@ -71,7 +71,7 @@ module gcp_gw_module {
 # OCI
 module oci_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "oci"
     name    = "foo-oci"
@@ -97,7 +97,7 @@ The following examples will launch a gateway with HA, in an existing VPC/VNet/VC
 # AWS
 module aws_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "aws"
     name    = "foo-aws"
@@ -119,7 +119,7 @@ module aws_gw_module {
 # Azure
 module arm_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "azure"
     name    = "foo-azure"
@@ -141,7 +141,7 @@ module arm_gw_module {
 # GCP
 module gcp_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "gcp"
     name    = "foo-gcp"
@@ -160,7 +160,7 @@ module gcp_gw_module {
 # OCI
 module oci_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "oci"
     name    = "foo-oci"
@@ -188,7 +188,7 @@ The following examples will launch a VPC + VPN gateway, with some sample VPN con
 # AWS
 module aws_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "aws"
     name    = "foo-aws"
@@ -219,7 +219,7 @@ module aws_gw_module {
 # Azure
 module arm_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "azure"
     name    = "foo-azure"
@@ -250,7 +250,7 @@ module arm_gw_module {
 # GCP
 module gcp_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "gcp"
     name    = "foo-gcp"
@@ -277,7 +277,7 @@ module gcp_gw_module {
 # OCI
 module oci_gw_module {
     source  = "terraform-aviatrix-modules/mc-gateway/aviatrix"
-    version = "1.3.0"
+    version = "1.3.1"
 
     cloud   = "oci"
     name    = "foo-oci"

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,13 @@ resource "aviatrix_gateway" "default" {
   fault_domain        = local.cloud == "oci" ? var.fault_domain : null
   zone                = local.zone
 
+  # Custom IP settings
+  allocate_new_eip                         = var.allocate_new_eip
+  eip                                      = var.eip
+  peering_ha_eip                           = var.ha_eip
+  azure_eip_name_resource_group            = var.azure_eip_name_resource_group
+  peering_ha_azure_eip_name_resource_group = var.ha_azure_eip_name_resource_group
+
   # HA options
   single_az_ha                   = var.single_az_ha
   peering_ha_subnet              = var.enable_ha ? local.ha_subnet : null

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aviatrix_vpc" "default" {
   subnet_size         = var.subnet_size
   resource_group      = var.resource_group
   num_of_subnet_pairs = var.num_of_subnet_pairs
-  
+
   dynamic "subnets" {
     for_each = local.cloud == "gcp" ? ["dummy"] : [] # Workaround to make block conditional. Count not available on dynamic blocks
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -173,6 +173,36 @@ variable "az_support" {
   default     = true
 }
 
+variable "allocate_new_eip" {
+  description = "Set to false to reuse an idle address in Elastic IP pool for this gateway. Otherwise, allocate a new Elastic IP and use it for this gateway"
+  type        = bool
+  default     = true
+}
+
+variable "eip" {
+  description = "Required when allocate_new_eip is false. It uses the specified EIP for this gateway"
+  type        = string
+  default     = null
+}
+
+variable "ha_eip" {
+  description = "Required when allocate_new_eip is false. It uses the specified EIP for this HA gateway"
+  type        = string
+  default     = null
+}
+
+variable "azure_eip_name_resource_group" {
+  description = "Name of public IP Address resource and its resource group in Azure to be assigned to the gateway instance"
+  type        = string
+  default     = null
+}
+
+variable "ha_azure_eip_name_resource_group" {
+  description = "Name of public IP Address resource and its resource group in Azure to be assigned to the HA gateway instance"
+  type        = string
+  default     = null
+}
+
 ## Advanced options
 variable "insane_mode" {
   description = "Set to true to enable Aviatrix high performance encryption. Only supported for AWS and Azure"


### PR DESCRIPTION
- Gateway now supports specifying the public IP address for both the primary and HA instance through the use of the following variables:
  - ``allocate_new_eip``
  - ``eip``
  - ``ha_eip``
  - ``azure_eip_name_resource_group``
  - ``ha_azure_eip_name_resource_group``
- This feature is available for all the current supported CSPs: AWS, Azure, GCP, and OCI