### PR TITLE
fix: sensitive outputs

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -5,4 +5,5 @@ output "vpc" {
 output "gateway" {
   description = "The Aviatrix gateway created, as an object with all attributes outputted."
   value       = aviatrix_gateway.default
+  sensitive   = true
 }


### PR DESCRIPTION
```╷
│ Error: Output refers to sensitive values
│ 
│   on output.tf line 5:
│    5: output "gateway" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
```