### PR TITLE
feat: custom_elb_name bool

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aviatrix_gateway" "default" {
   max_vpn_conn   = var.enable_vpn ? var.max_vpn_connections : null
   enable_vpn_nat = var.enable_vpn ? var.enable_vpn_nat : null
   enable_elb     = local.enable_elb
-  elb_name       = local.enable_elb ? "${local.name}-elb" : null
+  elb_name       = local.enable_elb && var.custom_elb_name ? "${local.name}-elb" : null
   saml_enabled   = var.saml_enabled
 
   idle_timeout           = var.enable_vpn && (var.idle_timeout > 300) ? var.idle_timeout : null

--- a/variables.tf
+++ b/variables.tf
@@ -339,3 +339,10 @@ variable "gw_amount" {
   default     = 1
   nullable    = false
 }
+
+variable "custom_elb_name" {
+  description = "Set to true to use custom ELB name. If false, the module will set elb_name to `null`."
+  type        = bool
+  default     = true
+}
+


### PR DESCRIPTION
I need a way to set this value to `null` so that I don't recreate the vpn gateway after import. Feel free to adjust this to another variable.